### PR TITLE
Point to local rails app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/Theme.HotwireNativeApplication"
-            tools:targetApi="31">
+            tools:targetApi="31"
+            android:usesCleartextTraffic="true"> <!-- Allows non-HTTPS traffic -->
         <activity
                 android:name=".MainActivity"
                 android:exported="true">

--- a/app/src/main/java/com/example/hotwirenativeapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/hotwirenativeapplication/MainActivity.kt
@@ -13,7 +13,7 @@ class MainActivity : HotwireActivity() {
     override fun navigatorConfigurations() = listOf(
         NavigatorConfiguration(
             name = "main",
-            startLocation = "https://hotwire-native-demo.dev",
+            startLocation = "http://10.0.2.2:3000",
             navigatorHostId = R.id.main_nav_host
         )
     )


### PR DESCRIPTION
To point to the local rails app, the start location has to be set to `http://10.0.2.2:3000` since this is an alias that the Android emulator uses to refer to the host machine, allowing the app running in the emulator to access services running on it (in this case, at the port `3000`.
`android:usesCleartextTraffic="true">` allows non-HTTPS traffic, which is blocked by default since Android 9.